### PR TITLE
Added - Vehicle AT Ammo

### DIFF
--- a/addons/norwegian_armed_forces/vehicles/Bell_412.hpp
+++ b/addons/norwegian_armed_forces/vehicles/Bell_412.hpp
@@ -43,6 +43,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -89,6 +90,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/CH47.hpp
+++ b/addons/norwegian_armed_forces/vehicles/CH47.hpp
@@ -18,6 +18,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -58,6 +59,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/CV90.hpp
+++ b/addons/norwegian_armed_forces/vehicles/CV90.hpp
@@ -451,6 +451,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/Humvee.hpp
+++ b/addons/norwegian_armed_forces/vehicles/Humvee.hpp
@@ -22,6 +22,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -66,6 +67,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -110,6 +112,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -154,6 +157,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -198,6 +202,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -242,6 +247,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -286,6 +292,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -330,6 +337,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -374,6 +382,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -418,6 +427,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -462,6 +472,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/M113.hpp
+++ b/addons/norwegian_armed_forces/vehicles/M113.hpp
@@ -220,6 +220,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -420,6 +421,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -822,6 +824,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/Scania.hpp
+++ b/addons/norwegian_armed_forces/vehicles/Scania.hpp
@@ -55,6 +55,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -111,6 +112,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/Stryker.hpp
+++ b/addons/norwegian_armed_forces/vehicles/Stryker.hpp
@@ -24,6 +24,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -70,6 +71,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -116,6 +118,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -162,6 +165,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {
@@ -208,6 +212,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			ARMOURED_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO_EXTE
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/UH1H.hpp
+++ b/addons/norwegian_armed_forces/vehicles/UH1H.hpp
@@ -69,6 +69,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {
@@ -109,6 +110,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/UH60.hpp
+++ b/addons/norwegian_armed_forces/vehicles/UH60.hpp
@@ -33,6 +33,7 @@ class CfgVehicles {
 
 		class TransportItems {
 			AIR_VEHICLE_ITEMS
+			VEHICLE_AT_AMMO
 		};
 
 		class TransportBackpacks {

--- a/addons/norwegian_armed_forces/vehicles/index.hpp
+++ b/addons/norwegian_armed_forces/vehicles/index.hpp
@@ -65,7 +65,29 @@ class _xx_ACE_tourniquet { \
 class _xx_ACE_EarPlugs { \
 	name = "ACE_EarPlugs"; \
 	count = 5; \
+}; 
+
+#define VEHICLE_AT_AMMO \
+class _xx_MRAWS_HE_F { \
+	name = "MRAWS_HE_F"; \
+	count = 1; \
+}; \
+class _xx_MRAWS_HEAT_F { \
+	name = "MRAWS_HEAT_F"; \
+	count = 1; \
 };
+
+#define VEHICLE_AT_AMMO_EXTE \
+class _xx_MRAWS_HE_F { \
+	name = "MRAWS_HEAT_F"; \
+	count = 3; \
+}; \
+class _xx_MRAWS_HE_F { \
+	name = "MRAWS_HE_F"; \
+	count = 1; \
+};
+
+
 
 #define VEHICLE_BACKPACKS
 
@@ -86,7 +108,9 @@ class _xx_rhs_weap_fim92 { \
 	count = 1; \
 };
 
-#define ARMOURED_VEHICLE_ITEMS VEHICLE_ITEMS
+#define ARMOURED_VEHICLE_ITEMS \
+VEHICLE_ITEMS \
+
 
 #define ARMOURED_VEHICLE_BACKPACKS \
 class _xx_BNB_FA_NAF_Toolkit_Backpack { \

--- a/readme.md
+++ b/readme.md
@@ -32,13 +32,10 @@
 - [CBA A3](https://steamcommunity.com/sharedfiles/filedetails/?id=450814997)
 - [RHS AFRF](https://steamcommunity.com/sharedfiles/filedetails/?id=843425103)
 - [RHS USAF](https://steamcommunity.com/sharedfiles/filedetails/?id=843577117)
-- [RHS GREF](https://steamcommunity.com/sharedfiles/filedetails/?id=843593391)
 - [NORSOF_LITE_mas](https://steamcommunity.com/sharedfiles/filedetails/?id=1654680843)
 - [NIArms HK416 Rifles](https://steamcommunity.com/sharedfiles/filedetails/?id=1519157834)
 - [NIArms G3 Rifles](https://steamcommunity.com/sharedfiles/filedetails/?id=667375637)
-- [Project OPFOR](https://steamcommunity.com/sharedfiles/filedetails/?id=735566597)
 - [ILBE Assault Pack - Rewrite](https://steamcommunity.com/sharedfiles/filedetails/?id=1875281645)
-- [MLO - All-in-one Collection](https://steamcommunity.com/sharedfiles/filedetails/?id=823636749)
 
 # Credits
 - Tittoffer and Martin M. from Norwegian Task Force for access to their assets made available to us with permission from the [NorwegianTaskForce Github](https://github.com/Tittoffer/NorwegianTaskForce/), which we then modified and built upon to make them our own


### PR DESCRIPTION
Added AT ammo combinations of 1 HEAT/1HE or 3 HEAT/1 HE into a number of NAF vehicles as per suggestion from Klonke and issue #20 
Also updated Readme's list of dependencies to remove references to mods removed in v4.0

close #20 